### PR TITLE
fix: not authorizing if no password specified

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -58,11 +58,9 @@ class EsphomeNativeApiConnection extends EventEmitter {
             this.connected = true;
             try {
                 await this.helloService(this.clientInfo);
-                if (this.password) {
-                    const { invalidPassword } =  await this.connectService(this.password);
-                    if (invalidPassword === true) throw new Error(`Invalid password`);
-                    this.authorized = true;
-                }
+                const { invalidPassword } =  await this.connectService(this.password);
+                if (invalidPassword === true) throw new Error(`Invalid password`);
+                this.authorized = true;
             } catch(e) {
                 this.emit('error', e);
                 this.socket.end();


### PR DESCRIPTION
A number of the requests (such as Subscribing to Bluetooth advertisements) require the ConnectRequest to be sent, and if it's not sent the socket is closed by the esphome device. The ConnectRequest is never sent if the device doesn't have an API password.

Making the ConnectRequest without a password is totally valid and stops the socket being forcibly closed by the esphome device.