### PR TITLE
Support for mapping responses

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,6 +4,21 @@ const { Entities } = require('./entities');
 const { serialize, deserialize, pb } = require('./utils/messages');
 const Package = require('../package.json');
 
+const base64Decode = (message) =>
+    message ? Buffer.from(message, 'base64').toString('ascii') : message;
+
+const mapMessageByType = (type, obj) => {
+    switch (type) {
+        case 'SubscribeLogsResponse': {
+            // decode message to string
+            const message = base64Decode(obj.message);
+            return { ...obj, message };
+        }
+        default:
+            return obj;
+    }
+};
+
 class EsphomeNativeApiConnection extends EventEmitter {
     constructor({
         port = 6053,
@@ -30,8 +45,9 @@ class EsphomeNativeApiConnection extends EventEmitter {
                 while (message = deserialize(this.buffer)) {
                     this.buffer = this.buffer.slice(message.length);
                     const type = message.constructor.type;
-                    this.emit(`message.${type}`, message.toObject());
-                    this.emit('message', type, message.toObject());
+                    const mapped = mapMessageByType(type, message.toObject());
+                    this.emit(`message.${type}`, mapped);
+                    this.emit('message', type, mapped);
                 }
             } catch (e) {
                 this.emit('error', e);


### PR DESCRIPTION
Recent changes to the aioesphomeapi api proto resulted in a change to the response payload for subscribe logs...  aioesphomeapi maps all the responses to an intermediary type so they could "hide" this change from consumers.