### PR TITLE
Bluetooth fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -276,23 +276,27 @@ declare module "@2colors/esphome-native-api" {
         sendFailed: boolean;
     };
 
+    export type BluetoothServiceData = {
+        uuid: string;
+        legacyDataList: Uint8Array;
+        data: string;
+    };
+
     export type BluetoothLEAdvertisementResponse = {
         address: number;
         name: string;
         rssi: number;
-        serviceDataList: {
-            uuid: string;
-            legacyDataList: Uint8Array;
-            data: string;
-        }[];
+        serviceUuidsList: string[];
+        serviceDataList: BluetoothServiceData[];
+        manufacturerDataList: BluetoothServiceData[];
         addressType: number;
     };
 
     export type BluetoothLERawAdvertisementsResponse = {
         address: number;
         rssi: number;
-        data: string;
         addressType: number;
+        data: string;
     };
 
     export type BluetoothDeviceConnectionResponse = {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -373,7 +373,7 @@ class EsphomeNativeApiConnection extends EventEmitter {
                 pb.BluetoothDeviceRequestType
                 .BLUETOOTH_DEVICE_REQUEST_TYPE_PAIR,
             ]),
-            'BluetoothDeviceConnectionResponse',
+            'BluetoothDevicePairingResponse',
             10
         );
     }
@@ -386,7 +386,7 @@ class EsphomeNativeApiConnection extends EventEmitter {
                 pb.BluetoothDeviceRequestType
                 .BLUETOOTH_DEVICE_REQUEST_TYPE_UNPAIR,
             ]),
-            'BluetoothDeviceConnectionResponse',
+            'BluetoothDeviceUnpairingResponse',
             10
         );
     }

--- a/lib/utils/mapMessageByType.js
+++ b/lib/utils/mapMessageByType.js
@@ -48,6 +48,10 @@ const ESP_BLE_AD_TYPE_32SERVICE_DATA = 0x1C;
 const ESP_BLE_AD_TYPE_128SERVICE_DATA = 0x1D;
 const ESP_BLE_AD_MANUFACTURER_SPECIFIC_TYPE = 0xFF;
 const mapRawAdvertisement = ({data, ...advertisement}) => {
+    if (!advertisement.serviceUuidsList) advertisement.serviceUuidsList = [];
+    if (!advertisement.serviceDataList) advertisement.serviceDataList = [];
+    if (!advertisement.manufacturerDataList) advertisement.manufacturerDataList = [];
+
     const payload = new Uint8Array(Buffer.from(data, 'base64'));
     const len = payload.length;
     let offset = 0;
@@ -68,7 +72,6 @@ const mapRawAdvertisement = ({data, ...advertisement}) => {
             }
             case ESP_BLE_AD_TYPE_16SRV_CMPL:
             case ESP_BLE_AD_TYPE_16SRV_PART: {
-                if (!advertisement.serviceUuidsList) advertisement.serviceUuidsList = [];
                 for (let i = 0; i < recordLength / 2; i++) {
                     advertisement.serviceUuidsList.push(makeShortUuid(record.slice(i*2), 2));
                 }
@@ -76,7 +79,6 @@ const mapRawAdvertisement = ({data, ...advertisement}) => {
             }
             case ESP_BLE_AD_TYPE_32SRV_CMPL:
             case ESP_BLE_AD_TYPE_32SRV_PART: {
-                if (!advertisement.serviceUuidsList) advertisement.serviceUuidsList = [];
                 for (let i = 0; i < recordLength / 4; i++) {
                     advertisement.serviceUuidsList.push(makeShortUuid(record.slice(i*4), 4));
                 }
@@ -84,7 +86,6 @@ const mapRawAdvertisement = ({data, ...advertisement}) => {
             }
             case ESP_BLE_AD_TYPE_128SRV_CMPL:
             case ESP_BLE_AD_TYPE_128SRV_PART: {
-                if (!advertisement.serviceUuidsList) advertisement.serviceUuidsList = [];
                 for (let i = 0; i < recordLength / 16; i++) {
                     advertisement.serviceUuidsList.push(makeFullUuid(record.slice(i*16)));
                 }
@@ -92,28 +93,24 @@ const mapRawAdvertisement = ({data, ...advertisement}) => {
             }
             case ESP_BLE_AD_MANUFACTURER_SPECIFIC_TYPE: {
                 if (recordLength < 2) break;
-                if (!advertisement.manufacturerDataList) advertisement.manufacturerDataList = [];
                 const uuid = makeShortUuid(record, 2)
                 advertisement.manufacturerDataList.push({uuid, legacyDataList: Array.from(record.slice(2)), data:""});
                 break;
             }
             case ESP_BLE_AD_TYPE_SERVICE_DATA: {
                 if (recordLength < 2) break;
-                if (!advertisement.serviceDataList) advertisement.serviceDataList = [];
                 const uuid = makeShortUuid(record, 2)
                 advertisement.serviceDataList.push({uuid, legacyDataList: Array.from(record.slice(2)), data:""});
                 break;
             }
             case ESP_BLE_AD_TYPE_32SERVICE_DATA: {
                 if (recordLength < 4) break;
-                if (!advertisement.serviceDataList) advertisement.serviceDataList = [];
                 const uuid = makeShortUuid(record, 4)
                 advertisement.serviceDataList.push({uuid, legacyDataList: Array.from(record.slice(4)), data:""});
                 break;
             }
             case ESP_BLE_AD_TYPE_128SERVICE_DATA: {
                 if (recordLength < 16) break;
-                if (!advertisement.serviceDataList) advertisement.serviceDataList = [];
                 const uuid = makeFullUuid(record)
                 advertisement.serviceDataList.push({uuid, legacyDataList: Array.from(record.slice(16)), data:""});
                 break;


### PR DESCRIPTION
When pairing or unpairing, the logic was waiting for the wrong response... this fixes that.
When processing a raw BLE advertisement the `serviceUuidsList`, `serviceDataList`, and `manufacturerDataList` weren't initiated, however, when a non-raw BLE advertisement was processed they would be... this makes them consistent.
Lastly, this updates the types of advertisements to include the three list fields that were previously missed.