### PR TITLE
More changes to BT logic

### DIFF
--- a/lib/utils/mapMessageByType.js
+++ b/lib/utils/mapMessageByType.js
@@ -29,8 +29,23 @@ const uuidFromBytes = (bytes, len = -1) => {
 
     return segments.join("");
 }
+const BT_BASE_UUID_SUFFIX = "0000-1000-8000-00805f9b34fb";
 const makeShortUuid = (bytes, len = -1) => {
-    return ["0x", uuidFromBytes(bytes, len).toUpperCase()].join("");
+    return [
+        uuidFromBytes(bytes, len).padStart(8, "0"),
+        BT_BASE_UUID_SUFFIX
+    ]
+        .join("-")
+        .toLowerCase();
+};
+const ensureFullUuid = (uuid) => {
+    if(!uuid.startsWith("0x")) return uuid.toLowerCase();
+    return [
+        uuid.substring(2).padStart(8, "0"),
+        BT_BASE_UUID_SUFFIX
+    ]
+        .join("-")
+        .toLowerCase();
 }
 const makeFullUuid = (bytes) => {
     return Array.from(bytes.slice(0, 16).reverse())
@@ -133,7 +148,11 @@ const mapMessageByType = (type, obj) => {
         case "BluetoothLEAdvertisementResponse": {
             // decode name to string
             const name = base64Decode(obj.name);
-            return { ...obj, name };
+            // tidy up advertised uuid
+            const serviceUuidsList = (obj.serviceUuidsList || []).map(uuid => ensureFullUuid(uuid));
+            const serviceDataList = (obj.serviceDataList || []).map(sd => sd.uuid = ensureFullUuid(sd.uuid));
+            const manufacturerDataList = (obj.manufacturerDataList || []).map(md => md.uuid = ensureFullUuid(md.uuid));
+            return { ...obj, name, serviceUuidsList, serviceDataList, manufacturerDataList };
         }
         case "BluetoothLERawAdvertisementsResponse": {
             const { advertisementsList, ...rest } = obj;

--- a/lib/utils/mapMessageByType.js
+++ b/lib/utils/mapMessageByType.js
@@ -14,20 +14,11 @@ const uuidDecode = (segments) =>
         .map((segment) => BigInt(segment).toString(16).padStart(16, "0"))
         .join("")
         .replace(uuidRegex, "$1-$2-$3-$4-$5");
-const hexBytesToNumber = bytes => bytes.reduce((acc, cur) => (acc << 8)+cur, 0);
 const uuidFromBytes = (bytes, len = -1) => {
     if(len === -1) len = bytes.length;
-    bytes = bytes.slice(0, len).reverse();
-    const segments = [];
-    while(len>8) {
-        segments.push(hexBytesToNumber(bytes.slice(0, 8)).toString(16).padStart(16,'0'));
-        bytes = bytes.slice(8);
-        len -= 8;
-    }
-    if(len>0)
-        segments.push(hexBytesToNumber(bytes).toString(16).padStart(len*2,'0'));
-
-    return segments.join("");
+    return Array.from(bytes.slice(0, len).reverse())
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("");
 }
 const BT_BASE_UUID_SUFFIX = "0000-1000-8000-00805f9b34fb";
 const makeShortUuid = (bytes, len = -1) => {
@@ -48,9 +39,7 @@ const ensureFullUuid = (uuid) => {
         .toLowerCase();
 }
 const makeFullUuid = (bytes) => {
-    return Array.from(bytes.slice(0, 16).reverse())
-        .map((b) => b.toString(16).padStart(2, "0"))
-        .join("")
+    return uuidFromBytes(bytes, 16)
         .replace(uuidRegex, "$1-$2-$3-$4-$5")
         .toLowerCase();
 };

--- a/lib/utils/mapMessageByType.js
+++ b/lib/utils/mapMessageByType.js
@@ -33,8 +33,12 @@ const makeShortUuid = (bytes, len = -1) => {
     return ["0x", uuidFromBytes(bytes, len).toUpperCase()].join("");
 }
 const makeFullUuid = (bytes) => {
-    return uuidFromBytes(bytes, 16).replace(uuidRegex, "$1-$2-$3-$4-$5");
-}
+    return Array.from(bytes.slice(0, 16).reverse())
+        .map((b) => b.toString(16).padStart(2, "0"))
+        .join("")
+        .replace(uuidRegex, "$1-$2-$3-$4-$5")
+        .toLowerCase();
+};
 const ESP_BLE_AD_TYPE_16SRV_PART = 0x02;
 const ESP_BLE_AD_TYPE_16SRV_CMPL = 0x03;
 const ESP_BLE_AD_TYPE_32SRV_PART = 0x04;


### PR DESCRIPTION
There were two issues:
- The Raw BLE advertisements that had 128-bit uuids were getting converted incorrectly. This correctly handles the 16-byte variant properly 
- UUIDs in BLE advertisements were sometimes short (16 or 32-bit) and sometimes long (128-bit) but always uppercase. When getting the service list the uuids were always long and always lowercase. This ensures all uuids are long and lowercase in all advertisement types.